### PR TITLE
Fix README run oneliner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ the following commands:
 
 ```console
 john@localhost:~$ export PS5_HOST=ps5
-john@localhost:~$ wget -q -O - https://github.com/ps5-payload-dev/shsrv/releases/latest/download/Payload.zip | gunzip -c -d | nc -q0 $PS5_HOST 9021
+john@localhost:~$ wget -q -O - https://github.com/ps5-payload-dev/shsrv/releases/latest/download/shsrv-ps5.elf | nc -q0 $PS5_HOST 9021
 john@localhost:~$ telnet $PS5_HOST 2323
 ```
 


### PR DESCRIPTION
The GitHub releases started to bundle the ELF directly instead of having a `Payload.zip` file.